### PR TITLE
Add Feature to Enter Room Via Url

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -54,6 +54,11 @@
                 <use xlink:href="#enter" />
             </svg>
         </a>
+        <a id="share-room-url" class="icon-button" title="Share room via URL" hidden>
+            <svg class="icon">
+                <use xlink:href="#shareroomurl" />
+            </svg>
+        </a>
         <a id="messages" style="display: none;" class="icon-button" title="Show Received Messages" >
             <svg class="icon">
                 <use xlink:href="#clipboard" />
@@ -259,6 +264,9 @@
         </symbol>
         <symbol id="exit" viewBox="-170 -150 1229 1229">
             <path d="M640 768H384V192L128 64h512v192h64V0H0v832l384 192V832h320V512h-64V768zM1024 384L768 192v128H512v128h256v128L1024 384z"/>
+        </symbol>
+        <symbol id="shareroomurl" viewBox="-1 -2 20 20">
+            <path d="M11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.499 2.499 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5z"/>
         </symbol>
         <symbol id="clipboard" viewBox="-3 -2 22 22">
             <path d="M13,0H3C1.35,0,0,1.35,0,3v12c0,1.65,1.35,3,3,3h10c1.65,0,3-1.35,3-3V3C16,1.35,14.65,0,13,0z M5,2h6v1c0,0.55-0.45,1-1,1H6C5.45,4,5,3.55,5,3V2z M14,15c0,0.55-0.45,1-1,1H3c-0.55,0-1-0.45-1-1V3c0-0.55,0.45-1,1-1h1 c0,0.26,0,0.6,0,1c0,1.1,0.9,2,2,2h4c1.1,0,2-0.9,2-2c0-0.4,0-0.74,0-1h1c0.55,0,1,0.45,1,1V15z M12,14H4c-0.28,0-0.5-0.22-0.5-0.5 S3.72,13,4,13h8c0.28,0,0.5,0.22,0.5,0.5S12.28,14,12,14z M12,11H4c-0.28,0-0.5-0.22-0.5-0.5S3.72,10,4,10h8 c0.28,0,0.5,0.22,0.5,0.5S12.28,11,12,11z M12,8H4C3.72,8,3.5,7.78,3.5,7.5S3.72,7,4,7h8c0.28,0,0.5,0.22,0.5,0.5S12.28,8,12,8z"/>

--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -570,7 +570,7 @@ class Events {
 
 RTCPeer.config = {
     'sdpSemantics': 'unified-plan',
-    'iceServers': [
-    urls: 'stun:stun.l.google.com:19302'
-    ]
+    'iceServers': [{
+        urls: 'stun:stun.l.google.com:19302'
+    }]
 }

--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -20,6 +20,7 @@ Events.on('display-name', e => {
         $displayNote.textContent = 'You can be discovered by everyone in this room';
         $('room').querySelector('svg use').setAttribute('xlink:href', '#exit');
         $('room').title = 'Exit The Room';
+        $('share-room-url').removeAttribute('hidden');
         $$('x-no-peers h2').textContent = 'Input room number on other devices to send files';
     } else {
         $displayName.textContent = 'Your device code is: ' + me.displayName;
@@ -332,6 +333,16 @@ class JoinRoomDialog extends Dialog {
         this.$text = this.$el.querySelector('#roomInput');
         const button = this.$el.querySelector('form');
         button.addEventListener('submit', e => this._join(e));
+        $('share-room-url').addEventListener('click', () => this._shareRoomViaURL());
+
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('room_id')) {
+            let inputNum = urlParams.get('room_id');
+            if (inputNum.length === 6 && !isNaN(inputNum)) {
+                sessionStorage.setItem("roomId", inputNum);
+                location.replace(location.origin); //remove room_id from url
+            }
+        }
     }
 
     _joinExit(e) {
@@ -357,6 +368,20 @@ class JoinRoomDialog extends Dialog {
             sessionStorage.setItem("roomId", inputNum);
             location.reload();
         }
+    }
+
+    _shareRoomViaURL() {
+        let url = new URL(location.href)
+        url.searchParams.append('room_id', sessionStorage.getItem("roomId"))
+        console.debug(url);
+        navigator.clipboard.writeText(url.href).then(
+            () => {
+                Events.fire('notify-user', 'URL copied to clipboard');
+            },
+            () => {
+                Events.fire('notify-user', 'Could not copy url to clipboard');
+            }
+        )
     }
 }
 


### PR DESCRIPTION
This pull request introduces to possibility to enter any room via the url parameter 'room_id'.

To enter a room:
- open e.g. `https://www.wulingate.com/en/?room_id=123456`
- room is 123456 is joined
- url is changed to `https://www.wulingate.com/en/`

To share a room:
- join a room
- click 'Share room via url' button
- share url is copied to clipboard

This partly implements #8 and fixes #7