### PR TITLE
Implement persistent room ids for PWAs

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -570,7 +570,7 @@ class Events {
 
 RTCPeer.config = {
     'sdpSemantics': 'unified-plan',
-    'iceServers': [
-    urls: 'stun:stun.l.google.com:19302'
-    ]
+    'iceServers': [{
+        urls: 'stun:stun.l.google.com:19302'
+    }]
 }

--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -335,7 +335,7 @@ class JoinRoomDialog extends Dialog {
 
         //retrieve roomId from db and write to sessionStorage if not null/undefined
         PersistentStorage.get('roomId').then((roomId) => {
-            if (roomId && roomId !== sessionStorage.getItem('roomId')) {
+            if (roomId && !sessionStorage.getItem('roomId')) {
                 sessionStorage.setItem('roomId', roomId);
                 location.reload()
             }


### PR DESCRIPTION
This pull request implements [indexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) to make rooms persistent.

When the tab is closed the room id is saved in a indexedDB store and is retrieved when the page is loaded again.
This way the user does not have to enter the room manually everytime the page is loaded.
When the room is left the room id is deleted in store.

This is especially useful with PWAs as entering a room with an url parameter as implemented with #9 is not suffienct with those. PWAs are always installed with a specific start url which can not be changed on installation.
With this PR merged, users can simply reopen their PWA to automatically enter the room they joined last.

As a secondary effect all instances opened in one browser after an instance entered a room are now opened automatically in the same room. This does not affect instances that are already in a room.